### PR TITLE
FIX: cargo should not cache from local host

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,6 @@
 	"build":{
 		"dockerfile": "Dockerfile"
 	},
-	"mounts": [
-		"source=${localEnv:HOME}/.cargo,target=/usr/local/cargo,type=bind,consistency=cached"
-	],
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/rust:1": {},
@@ -21,7 +18,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "rustc --version",
+	"postCreateCommand": "rustc --version",
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
Removed the mount section of the devcontainer.json to enable correct behavior on mac os x. Probably we should not map local host .cargo to the container one by default.